### PR TITLE
Update 17 to use renamed RSS plugin APIs

### DIFF
--- a/17.md
+++ b/17.md
@@ -175,7 +175,7 @@ Let’s break down what’s happening here.
 
 1. We use XML for RSS feeds, so in our `permalink` we create `feed.xml`.
 2. After that, we set some information about our website, which we added in `site.json` earlier on.
-3. We then tell the feed reader (or whatever consumes this feed) when it was last updated. We do that with the `getNewestCollectionItemDate | dateToRfc3339` filter, provided by the RSS plugin by Eleventy. We pass the entire `blog` collection in there to do that.
+3. We then tell the feed reader (or whatever consumes this feed) when it was last updated. We do that with the `getNewestCollectionItemDate` and `dateToRfc3339` filters provided by the Eleventy RSS plugin. We pass the entire `blog` collection in there to do that.
 4. Then, we loop the `blog` collection and create an `<entry>` for each one. That entry contains links to the post. Because the post lives on the live site, we generate an `absolutePostUrl`, mixing the post’s URL with the `site.url`.
 
 You probably noticed that weird `<![CDATA[ ]]>` setup. This tells the XML parser not to treat whatever’s in there as XML. This is because there will be HTML in there. You can read more about [CDATA here](https://en.wikipedia.org/wiki/CDATA), if you fancy being bored out of your mind!

--- a/17.md
+++ b/17.md
@@ -175,7 +175,7 @@ Let’s break down what’s happening here.
 
 1. We use XML for RSS feeds, so in our `permalink` we create `feed.xml`.
 2. After that, we set some information about our website, which we added in `site.json` earlier on.
-3. We then tell the feed reader (or whatever consumes this feed) when it was last updated. We do that with the `rssLastUpdatedDate` filter, provided by the RSS plugin by Eleventy. We pass the entire `blog` collection in there to do that.
+3. We then tell the feed reader (or whatever consumes this feed) when it was last updated. We do that with the `getNewestCollectionItemDate | dateToRfc3339` filter, provided by the RSS plugin by Eleventy. We pass the entire `blog` collection in there to do that.
 4. Then, we loop the `blog` collection and create an `<entry>` for each one. That entry contains links to the post. Because the post lives on the live site, we generate an `absolutePostUrl`, mixing the post’s URL with the `site.url`.
 
 You probably noticed that weird `<![CDATA[ ]]>` setup. This tells the XML parser not to treat whatever’s in there as XML. This is because there will be HTML in there. You can read more about [CDATA here](https://en.wikipedia.org/wiki/CDATA), if you fancy being bored out of your mind!

--- a/17.md
+++ b/17.md
@@ -150,7 +150,7 @@ permalink: '/feed.xml'
 	<subtitle>{{ summary }}</subtitle>
 	<link href="{{ site.url }}{{ permalink }}" rel="self"/>
 	<link href="{{ site.url }}/"/>
-	<updated>{{ collections.blog | rssLastUpdatedDate }}</updated>
+	<updated>{{ collections.blog | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
 	<id>{{ site.url }}</id>
 	<author>
     <name>{{ site.authorName }}</name>
@@ -161,7 +161,7 @@ permalink: '/feed.xml'
     <entry>
       <title>{{ post.data.title }}</title>
       <link href="{{ absolutePostUrl }}"/>
-      <updated>{{ post.date | rssDate }}</updated>
+      <updated>{{ post.date | dateToRfc3339 }}</updated>
       <id>{{ absolutePostUrl }}</id>
       <content type="html"><![CDATA[
         {{ post.templateContent | safe }}


### PR DESCRIPTION
As per 11ty docs:

⚠️ Removed in RSS v2.0.0 rssLastUpdatedDate, poorly named (works with Atom and JSON feeds, not RSS). Use getNewestCollectionItemDate | dateToRfc3339 instead.

⚠️ Removed in RSS v2.0.0 rssDate, poorly named (works with Atom and JSON feeds, not RSS). Use dateToRfc3339 instead.