### PR TITLE
Version 3 and ESM Updates for Lesson 2

### DIFF
--- a/2.md
+++ b/2.md
@@ -5,26 +5,45 @@ title: 'Lesson 2: Hello world'
 
 Now we have a better idea of what Eleventy is and have the tools we need to get started, let’s make something that we can see in the browser.
 
-Remember dotfiles from the last lesson? Well now we’re going to add the most important dotfile of this entire project: `.eleventy.js`.
+Next we'll add one of the most important files for the project: `eleventy.config.js`.
 
-Create a new file in your `eleventy-from-scratch` folder called `.eleventy.js` and add the following to it:
+>[!INFO] CJS Modules to ESM
+> Previously for the course, CommonJS (CJS) was used to configure Eleventy as well as to export (`module.exports`) and import (`require()`) other js modules. Eleventy's recent update (version 3) now supports the use of ECMAScript Modules (ESM) which is now simply `export` and `import`. While either CJS or ESM can be used, ESM is the preferred implementation because its the standardised way to handle modules in both NodeJS and browser environments whereas the CJS module system was limited to just NodeJS. To keep things short and simple, CJS brings no benefits to browsers which this site is being developed for and can actually be a deteriment.
+
+Create a new file in your `eleventy-from-scratch` folder called `eleventy.config.js` and add the following to it:
 
 ```js
-module.exports = (config) => {
-	return {
-		dir: {
-			input: 'src',
-			output: 'dist',
-		},
-	};
+export default function(eleventyConfig) {
+
+    eleventyConfig.setInputDirectory("src");
+    eleventyConfig.setOutputDirectory("dist");
 };
 ```
 
+>[!TIP]
+> Asynchronous callbacks are also possible by writing the default configuration function like this:
+> ```js
+> export default async function(eleventyConfig) {
+> 	//Add config methods
+> };
+
 This is our [Eleventy config file](https://www.11ty.dev/docs/config/). It's the beating heart of your Eleventy site. It delegates and instructs everything that makes up the final output.
 
-What we've just added is the core, most basic config. We've [exported a function](https://nodejs.org/docs/latest-v12.x/api/modules.html#modules_module_exports) which returns some settings. These settings tell Eleventy to look in the **src** folder for all of our content, templates and other **source code**, and tell it to use **dist** as the output folder.
+What we've just added is the core, most basic config. We have defined a default export function where the object `eleventyConfig` gives us full access to Eleventy's configuration API allowing us to configure Eleventy's default behaviour. These settings tell Eleventy to look in the src folder (through the callback: `eleventyConfig.setInputDirectory("src")`) for all of our content, templates and other source code, and tell it to use dist `eleventyConfig.setOutputDirectory("dist")` as the output folder.
 
 Remember: the output will be folders and HTML pages (at the moment).
+
+>[!TIP] Shaping your Configuration File
+> With Eleventy version 3, you have a number of ways that you can build your configuration file. Using callback methods is the preferred way but as we'll see in the next lesson, not all configurations have a callback method to Eleventy's configuration API. You can even use the old implementation of returning configuration objects if you want (not preferred though):
+>```js
+>export default afunction(eleventyConfig) {
+>	return {
+>    dir: {
+>      input: "views",
+>      output: "dist"
+>    }
+>  };
+>};
 
 ## Adding some dependencies
 
@@ -45,20 +64,35 @@ You should see an output that looks like this:
 
 ```json
 {
-	"name": "eleventy-from-scratch",
-	"version": "1.0.0",
-	"description": "",
-	"main": ".eleventy.js",
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC"
+  "name": "eleventy-from-scratch",
+  "version": "1.0.0",
+  "main": "eleventy.config.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
 }
 ```
 
-What's happened here is that npm has generated a `package.json` file for us, and by using the `-y` flag, we told it to answer **yes** to all of the questions it would normally ask.
+What's happened here is that npm has generated a `package.json` file for us, and by using the `-y` flag, we told it to answer **yes** to all of the questions it would normally ask. Make sure `main` points to `eleventy.config.js` before continuing on.
+
+>[!TIP]
+>Does `main` point to `index.js` by any chance? This can occur for the following reasons:
+>
+>- You didn't run npm init -y in the root directory of your project where your configuration file should be.
+>- Your configuration file is a .mjs file. For some reason, npm won't set the main property to use .mjs configuration files.
+>Fret not if this happens. You can either edit `package.json` in a text editor and change the main property file to the name of your configuration file. Or you can delete the `package.json` file, make corrections to your configuration file with either its name or location and then run `npm init -y` again to make a new package.json file.
+
+Now for `package.json` to treat your configuration file as an ES module, run the following command:
+
+```sh
+npm pkg set type="module"
+```
+
+This will add the property `type: module` to `package.json` file. You can even edit `package.json` in the text editor and add it yourself if you want. You might even need to do this to edit some properties and or functions for your project later.
 
 Now that’s sorted, we can install Eleventy. In the terminal, run the following command:
 
@@ -119,19 +153,21 @@ Your `package.json` file should now look like this:
 
 ```json
 {
-	"name": "eleventy-from-scratch",
-	"version": "1.0.0",
-	"description": "",
-	"main": ".eleventy.js",
-	"scripts": {
-		"start": "npx eleventy --serve"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC",
-	"dependencies": {
-		"@11ty/eleventy": "^2.0.1"
-	}
+  "name": "eleventy-from-scratch",
+  "version": "1.0.0",
+  "main": "eleventy.config.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "stop": "npx eleventy --serve"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "type": "module",
+  "dependencies": {
+    "@11ty/eleventy": "^3.0.0"
+  }
 }
 ```
 


### PR DESCRIPTION
Lesson 2 got a number of updates:

-Config file name: `.eleventy.js` -> `eleventy.config.js`
-Eleventy's behaviour is now configured through Eleventy's configuration API
-`package.json` updates
-`package.json` additional configuration added to treat all `.js` files as ES Modules (saves us needing to format `.js` files as `.mjs`.
-More informative info boxes and tips to support changes.

Couple of changes but I'm expecting it to go downhill from here for the rest of the lessons. I also just realised a small typo at line 24.

Lesson1 needed no updates.